### PR TITLE
fix Sha1 to support numbers with leading zeros

### DIFF
--- a/NGitLab/NGitLab.Tests/Sha1Tests.cs
+++ b/NGitLab/NGitLab.Tests/Sha1Tests.cs
@@ -13,6 +13,13 @@ namespace NGitLab.Tests
         }
 
         [Test]
+        public void WhenSha1WithLeadingZero_ThenParsedCorrectly()
+        {
+            const string value = "59529D73E3E6E2B7015F05D197E12C43B13BA033";
+            Assert.AreEqual(value.ToUpper(), new Sha1(value).ToString().ToUpper());
+        }        
+
+        [Test]
         public void WhenSha1WithUpperCase_ThenParsedCorrectly()
         {
             const string value = "2695EFFB5807A22FF3D138D593FD856244E155E7";

--- a/NGitLab/NGitLab/Sha1.cs
+++ b/NGitLab/NGitLab/Sha1.cs
@@ -50,9 +50,9 @@ namespace NGitLab
 
         public override string ToString()
         {
-            return _p1.ToString("X") +
-                   _p2.ToString("X") +
-                   _p3.ToString("X");
+            return _p1.ToString("X16") +
+                   _p2.ToString("X16") +
+                   _p3.ToString("X8");
         }
 
         private static ulong GetLong(string value, ref int i)


### PR DESCRIPTION
Adds X16 or X8 to the Sha1.ToString() method to account for cases where there is a leading 0 in a number.