### PR TITLE
Fix UpdatedAt typo in MergeRequest model

### DIFF
--- a/NGitLab/NGitLab/Models/MergeRequest.cs
+++ b/NGitLab/NGitLab/Models/MergeRequest.cs
@@ -40,7 +40,7 @@ namespace NGitLab.Models
         public int Upvotes;
 
         [DataMember(Name = "updated_at")]
-        public DateTime UpvotedAt;
+        public DateTime UpdatedAt;
 
         [DataMember(Name="target_branch")]
         public string TargetBranch;


### PR DESCRIPTION
The public field was incorrectly named "UpvotedAt"