### PR TITLE
Add WIP and Labels to MergeRequest model

### DIFF
--- a/NGitLab/NGitLab/Models/MergeRequest.cs
+++ b/NGitLab/NGitLab/Models/MergeRequest.cs
@@ -56,5 +56,11 @@ namespace NGitLab.Models
 
         [DataMember(Name = "target_project_id")]
         public int TargetProjectId;
+
+        [DataMember(Name = "work_in_progress")]
+        public bool? WorkInProgress;
+
+        [DataMember(Name = "labels")]
+        public Collection<string> Labels;
     }
 }


### PR DESCRIPTION
Add fields for WorkInProgress and Labels, which are already exposed through the GitLab API as "work_in_progress" and "labels" respectively.